### PR TITLE
Move CI to ubuntu 20.04 from deprecated 18.04 runners

### DIFF
--- a/.github/workflows/check_release_label.yml
+++ b/.github/workflows/check_release_label.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check_labels:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: smartlyio/check-versioning-action@v5
       with:


### PR DESCRIPTION
GitHub is deliberately causing CI failures on ubuntu-18.04; we need to switch everything