### PR TITLE
Add lines flavor to use with SimpleCov coverage data

### DIFF
--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import axios from 'axios';
 import * as assert from 'assert';
 import * as glob from 'glob';
+
 type Opts = {
   coverage: string;
   token: string;

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs';
 import axios from 'axios';
 import * as assert from 'assert';
 import * as glob from 'glob';
-
 type Opts = {
   coverage: string;
   token: string;
@@ -34,7 +33,7 @@ export async function run(opts: Opts) {
 
 async function publishCoverage(opts: Opts) {
   const coverage = JSON.parse(fs.readFileSync(opts.coverage, 'utf8'));
-  for (const flavor of ['branches', 'statements', 'functions']) {
+  for (const flavor of ['branches', 'statements', 'functions', 'lines']) {
     const pct = coverage.total[flavor]?.pct;
     const coveredItems = coverage.total[flavor]?.covered;
     const totalItems = coverage.total[flavor]?.total;


### PR DESCRIPTION
For Ruby with SimpleCov we only seem to be able to get coverage for lines, branches and maybe methods. Therefore it would be nice to use the line based coverage there as it is pretty much the best we can do. Would it be ok to enable lines as default or do we need to not send them for projects that are not currently sending them?