### PR TITLE
Run action on Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: url to send the data to
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 12 is deprecated and will be removed at some point.

GItHub's own actions use major version for node version requirement bump, as it changes the runner version requirement. However, that is annoying to update across project and it looks like GitHub has forced actions to run on Node16 anyway: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
.