### PR TITLE
Support the "Unknown" pct edge case

### DIFF
--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -39,7 +39,7 @@ async function publishCoverage(opts: Opts) {
     const coveredItems = coverage.total[flavor]?.covered;
     const totalItems = coverage.total[flavor]?.total;
 
-    if (pct != null) {
+    if (pct != null && pct != "Unknown") {
       if (opts.token) {
         const data = {
           project: opts.project,


### PR DESCRIPTION
There is an edge case where the "Unknown" string gets generated upstream and it causes the action to post an invalid value and subsequently fail. This PR simply skips the case.