### PR TITLE
Pass dry-run flag from action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: Coverage file format (summary or istanbul)
     required: false
     default: istanbul
+  dry-run:
+    description: Dry run mode
+    required: false
+    default: 'false'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,8 @@ async function run() {
     tag: pr != null ? `pr-${pr}` : 'main',
     project: github.context.repo.repo,
     url: core.getInput(urlArgument),
-    coverageFormat: (core.getInput('coverage-format') ?? 'istanbul') as 'summary' | 'istanbul'
+    coverageFormat: (core.getInput('coverage-format') ?? 'istanbul') as 'summary' | 'istanbul',
+    dryRun: core.getInput('dry-run') === 'true'
   });
 }
 


### PR DESCRIPTION
There is a debug flag for the action, but it is not possible to use because dryRun only is exposed to the internal interface, not to action.