### PR TITLE
Don't emit declarations at all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-dist/*.d.ts

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
-    "declaration": true,
+    "declaration": false,
     "target": "es2017",
     "lib": ["es6", "es2017", "dom", "esnext.asynciterable"],
     "module": "commonjs",


### PR DESCRIPTION
Having gitignore can lead into surprising behaviours where action works in test, but not when committed. At least we'd need to clean up the repository first.

Better fix for broken build caused by #27 and hotfixed in #28.